### PR TITLE
Fixed: KeyError caused due to the same element getting removed from a…

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -435,6 +435,8 @@ def case_insensitive_partial_match_set_diff(set_a, set_b):
     for item_a in set_a:
         for item_b in set_b:
             if item_b.lower() in item_a.lower():
+                if item_a not in uncommon_items:
+                    continue
                 uncommon_items.remove(item_a)
     return uncommon_items
 


### PR DESCRIPTION
… set twice

for item_a in set_a:
    for item_b in set_b:
        if <some condition:True>:
            set_a.remove(item_a)

As you can see, if there are multiple items in set_b for which the condition evaluates to True, set_a.remove(item_a) will run twice, which will cause KeyError for second time onwards.

To solve this problem, I am checking whether the item_a is there in the set_a before removing. If it is, then remove, if it isn't then continue without removing as we have already removed it